### PR TITLE
chore(terraform): downgrade Terraform version to 1.15.5 in workflow a…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -429,7 +429,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4.0.1
         with:
-          terraform_version: "1.16.0"
+          terraform_version: "1.15.5"
 
       - name: Set deployment image tag
         id: image_tag

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,7 +6,7 @@ terraform {
       version = "2.87.0"
     }
   }
-  required_version = "1.16.0"
+  required_version = "1.15.5"
 
   # Backend configuration is handled by separate backend-*.tf files
   # based on the use_local_state variable


### PR DESCRIPTION
…nd main.tf

This commit updates the Terraform version in both the GitHub Actions workflow and the main Terraform configuration file to 1.15.5, ensuring consistency across the deployment setup.