### PR TITLE
fix(ansible): stop watchdog from killing healthy prod container

### DIFF
--- a/ansible/templates/docker-compose.yml.j2
+++ b/ansible/templates/docker-compose.yml.j2
@@ -4,7 +4,13 @@ services:
   # Define web service (for staging) and alias it as app (for production)
   web:
     image: "{{ docker_image }}"
-    pull_policy: always
+    # "missing" (not "always"): the deploy playbook already runs an explicit
+    # `docker-compose pull web` with a live CI-issued GHCR login right before
+    # `up`. A policy of "always" forces every *subsequent* `docker-compose up`
+    # (cron-driven recovery, a manual restart, host reboot) to re-authenticate
+    # to GHCR too — but those run long after the deploy job's GITHUB_TOKEN has
+    # expired, so the pull fails and the recreate is left with no container.
+    pull_policy: missing
     restart: always
 {% if next_public_environment == 'staging' %}
     build:

--- a/ansible/templates/monitor.sh.j2
+++ b/ansible/templates/monitor.sh.j2
@@ -33,12 +33,20 @@ if [ "$DISK_SPACE" -gt 90 ]; then
   docker system prune -af --volumes
 fi
 
-# Check Docker container status
+# Check Docker container status. Query the compose project directly rather
+# than grepping `docker ps` for "{{ project_name }}" — Compose names
+# containers after the project directory ("repo"), not this ansible var, so
+# the old "{{ project_name }}.*web" grep never matched anything and
+# force-recreated a perfectly healthy container on every single cron tick.
 cd {{ app_dir }}/repo
-if ! docker ps | grep -q "{{ project_name }}.*web"; then
+WEB_CONTAINER_ID=$(docker-compose ps -q web)
+if [ -z "$WEB_CONTAINER_ID" ] || [ "$(docker inspect -f '{% raw %}{{.State.Running}}{% endraw %}' "$WEB_CONTAINER_ID" 2>/dev/null)" != "true" ]; then
   log_message "Web container not running properly! Attempting to restart..."
-  docker-compose down web
-  docker-compose up -d web
+  # force-recreate in place instead of `down` + `up`: a full `down` tears
+  # down the network and removes the container before we know a replacement
+  # will actually start, which is what left the site with zero containers
+  # running when a later pull failed.
+  docker-compose up -d --force-recreate web
   sleep 15
 fi
 
@@ -46,7 +54,7 @@ fi
 if ! curl -s -f -o /dev/null -w "%{http_code}" $HEALTH_CHECK_URL | grep -q "200"; then
   log_message "Application not responding. Restarting services..."
   cd {{ app_dir }}/repo
-  docker-compose down --remove-orphans && docker-compose up -d web
+  docker-compose up -d --force-recreate --remove-orphans web
   sleep 5
   systemctl restart nginx
 fi


### PR DESCRIPTION
## Summary

Root cause of today's production outage — a cron watchdog (`monitor.sh`, ticks every 15 min) was tearing down and failing to recreate a perfectly healthy container after every deploy.

- `monitor.sh.j2` checked `docker ps | grep "{{ project_name }}.*web"` (`dotca-nextjs.*web`), but Compose names containers after the clone directory (`repo-web-1`), never `dotca-nextjs`. The check never matched, so every cron tick believed the container was down and ran `docker-compose down web && docker-compose up -d web`.
- `docker-compose.yml.j2` set `pull_policy: always`, so that forced recreate needed a fresh authenticated pull from GHCR every time — but the GHCR login on the droplet comes from the CI job's short-lived `secrets.GITHUB_TOKEN`, which is invalid by the time the token's owning job has ended.
- Net effect: the first cron tick after the deploy job's token expires does `down` (removing the healthy container), then the recreate's pull fails with `denied: denied`, leaving **zero containers running** until someone manually intervenes. Confirmed via `/app/monitoring.log` on the production droplet during the incident — repeating `down` → pull `denied: denied` cycles every 15 minutes with no container left standing.

## Changes

- `ansible/templates/docker-compose.yml.j2`: `pull_policy: always` → `missing`. The deploy playbook already runs an explicit authenticated `docker-compose pull web` immediately before `up`, so this was only ever needed for the CI-driven deploy path, not for any later restart (cron recovery, manual restart, reboot).
- `ansible/templates/monitor.sh.j2`: check container health via `docker-compose ps -q web` + `docker inspect .State.Running` (scoped to the actual compose project) instead of grepping for the ansible var. Replace destructive `docker-compose down` + `up` with `docker-compose up -d --force-recreate` so a failed pull can't leave the app dir with no container at all.
- Both `production-deploy.yml` and `staging-deploy.yml` reference these same shared templates, so this fixes both environments.

Validated both templates still render to valid syntax (Jinja render + YAML parse for the compose file) and `just ansible-syntax` passes.

## Test plan

- [ ] `just ansible-syntax` (already passing locally)
- [ ] Deploy to staging, confirm `monitor.sh` runs cleanly for a couple of cron cycles without recreating a healthy container (check `/app/monitoring.log`)
- [ ] Deploy to production, same check, and confirm no outage in the hour following deploy

## Incident context

Production (boximity.ca) went down ~15 min after PR #521 merged to `main` today (2026-07-20) — deploy itself succeeded and passed its own post-deploy health checks, but the watchdog above tore the container down shortly after and couldn't bring it back. Manually recovered by disabling the cron entry and force-starting with `pull_policy: missing` set locally; this PR makes that fix permanent.

https://claude.ai/code/session_01LnZzaUiFj1uiCh2d7y8Co9