### PR TITLE
fix(deploy): resolve correct image tag and stop silent cleanup failures on staging

### DIFF
--- a/ansible/staging-deploy.yml
+++ b/ansible/staging-deploy.yml
@@ -40,7 +40,7 @@
     github_token: "{{ GITHUB_TOKEN | default('') }}"
     github_username: "{{ GITHUB_USERNAME | default('bxmty') }}"
     # Try multiple possible image names based on repository
-    docker_image_override: "{{ DOCKER_IMAGE | default('ghcr.io/bxmty/dotca:staging') }}"
+    docker_image_override: "{{ DEPLOY_DOCKER_IMAGE | default('ghcr.io/bxmty/dotca:staging') }}"
     github_repo_from_url: "{{ GITHUB_REPO | default('bxmty/dotca') }}"
     docker_image: "{{ docker_image_override }}"
 
@@ -441,7 +441,7 @@
       ignore_errors: true
 
     - name: Remove corrupted image if inspection fails
-      ansible.builtin.command: docker rmi "{{ docker_image }}" || true
+      ansible.builtin.command: bash -c "docker rmi '{{ docker_image }}' || true"
       when: image_inspect is failed
       changed_when: false
 
@@ -456,9 +456,11 @@
 
     - name: Clean up Docker environment before starting services
       ansible.builtin.command: |
+        bash -c "
         docker-compose down --volumes --remove-orphans || true
         docker system prune -f || true
         docker volume prune -f || true
+        "
       args:
         chdir: "{{ app_dir }}"
       changed_when: false
@@ -475,7 +477,7 @@
       changed_when: false
 
     - name: Verify web container environment variables
-      ansible.builtin.command: docker-compose exec -T web env | grep -E "GA_"
+      ansible.builtin.command: bash -c "docker-compose exec -T web env | grep -E 'GA_'"
       args:
         chdir: "{{ app_dir }}"
       register: container_env


### PR DESCRIPTION
## Summary

Found while reviewing PR #531 ("Refactor services and home messaging for niche alignment"): its changes never showed up on `staging.boximity.ca` even though the CI/CD pipeline reported a fully green build → deploy → test run. Root cause is in `ansible/staging-deploy.yml`, not in #531 itself:

- **Wrong image resolved.** The playbook reads the Ansible var `DOCKER_IMAGE`, but the deploy action's generated inventory only ever sets `DEPLOY_DOCKER_IMAGE` (`.github/actions/deploy/action.yml:172`) — `production-deploy.yml` already uses the correct variable name. `DOCKER_IMAGE` is therefore always undefined in the staging play, so `docker_image_override` silently falls back to its default: the floating `ghcr.io/bxmty/dotca:staging` tag, never the commit-pinned `staging-<sha>` tag CI just built and tested. Confirmed in PR #531's own deploy log: it echoes `"🔨 Using freshly built image: staging-<sha>"` but the play's own debug task later prints `"Final docker_image: ghcr.io/bxmty/dotca:staging"`.
- **Cleanup step failing silently.** "Clean up Docker environment before starting services" ran `docker-compose down --volumes --remove-orphans || true` (plus two more `|| true` commands) directly under `ansible.builtin.command`, which does not invoke a shell — so `||`/`true`/the following commands were passed as literal argv to `docker-compose down`, which errored (`unknown shorthand flag: 'f' in -f`, rc=16) and was swallowed by `ignore_errors: true`. The old container was therefore never torn down ahead of `docker-compose up -d web`. Two other tasks in the same file had the identical bug (`docker rmi ... || true`, `docker-compose exec ... | grep`) — every other multi-command task in this file already wraps shell logic in `bash -c "..."`; these three didn't.

## Changes

- `docker_image_override` now reads `DEPLOY_DOCKER_IMAGE` (matching `production-deploy.yml`).
- The three affected `command` tasks now wrap their shell logic in `bash -c "..."`, consistent with every other multi-command task already in this file.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('ansible/staging-deploy.yml'))"` — YAML parses
- [x] `ansible-playbook --syntax-check staging-deploy.yml` — syntax OK
- [ ] Next merge to `staging` should deploy the exact `staging-<sha>` image and actually replace the running container — verify `staging.boximity.ca` reflects the latest merged content afterward
- [ ] Separately worth following up: the "E2E tests" CI step ran in 655ms via `playwright test --passWithNoTests`, which strongly suggests it matched zero test files and passed vacuously rather than actually checking deployed content — that's why this went unnoticed. Not fixed here; flagging for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181xXp1Ns15EQiKqd8CTZY7