### PR TITLE
fix(deploy): push full-length SHA image tags to match what deploy expects

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -376,7 +376,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
-            type=sha,prefix={{branch}}-
+            type=sha,prefix={{branch}}-,format=long
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary

Follow-up to #536. That PR fixed Ansible resolving the wrong (floating) image tag — but merging it triggered [run #189](https://github.com/bxmty/dotca/actions/runs/30938590964), which then failed at "Check if Docker image exists in GHCR" with `manifest unknown`.

Reason: `docker/metadata-action`'s `type=sha` tag defaults to `format=short` (7-char abbreviated SHA), so the build job pushed `ghcr.io/bxmty/dotca:staging-a13f26b`. Everything downstream expects the **full** 40-char SHA — `quality-and-build`'s own `image_tag: ${{ github.ref_name }}-${{ github.sha }}` output, and the Ansible playbook's `docker manifest inspect` check both use `github.sha`, which is always full-length. So the deploy job went looking for `ghcr.io/bxmty/dotca:staging-a13f26bae8f3b74742d0497172716f931146c51f`, which was never pushed.

This mismatch predates #536 — it was just never exercised, because the bug #536 fixed meant Ansible always fell back to the floating `:staging` tag before ever reaching the manifest-exists check.

## Change

One line: `type=sha,prefix={{branch}}-` → `type=sha,prefix={{branch}}-,format=long` in `.github/workflows/deploy.yml`'s `Extract metadata` step, so the pushed tag matches `github.sha` exactly.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` — YAML parses
- [ ] Next push to `staging` should push `ghcr.io/bxmty/dotca:staging-<full-sha>`, Ansible's manifest check should find it, and the deploy should actually replace the running container with PR #531's content
- [ ] Verify `staging.boximity.ca` reflects the latest merged content after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181xXp1Ns15EQiKqd8CTZY7