### PR TITLE
fix(sentry): tag events with actual environment, not NODE_ENV

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -9,7 +9,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
 
   // Environment tagging for better issue organization
-  environment: process.env.NODE_ENV,
+  environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
 
   // Release tracking for better error grouping and deployment tracking
   release: process.env.NEXT_PUBLIC_COMMIT_HASH,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -8,7 +8,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
 
   // Environment tagging for better issue organization
-  environment: process.env.NODE_ENV,
+  environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
 
   // Release tracking for better error grouping and deployment tracking
   release: process.env.NEXT_PUBLIC_COMMIT_HASH,

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -8,7 +8,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
 
   // Environment tagging for better issue organization
-  environment: process.env.NODE_ENV,
+  environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
 
   // Release tracking for better error grouping and deployment tracking
   release: process.env.NEXT_PUBLIC_COMMIT_HASH,


### PR DESCRIPTION
## Summary
- `Sentry.init({ environment })` at all three call sites (`sentry.server.config.ts`, `sentry.edge.config.ts`, `src/instrumentation-client.ts`) read `NODE_ENV`, which is hardcoded to `production` for both staging and production builds (`.github/workflows/deploy.yml`), so staging events were indistinguishable from production ones in Sentry.
- Switched all three to `NEXT_PUBLIC_ENVIRONMENT`, which is already correctly per-environment and delivered as a runtime container env var to server, edge, and client alike.
- `tracesSampleRate` (also gated on `NODE_ENV`) and the `release` field are left untouched — out of scope per the issue, a separate product decision.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (only pre-existing unrelated warnings)
- [x] `npm run test` — all suites pass
- [ ] Deploy to staging and confirm a raised error is tagged `environment: staging` in Sentry
- [ ] Deploy to production and confirm a raised error is tagged `environment: production` in Sentry

Fixes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ceo4rGz6AHH9QBJite9Xkg