### PR TITLE
Promote staging to main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,13 @@ WEBMASTER_EMAIL=hi@boximity.ca
 GA_STAGING_ID=G-XXXXXXXXXX
 GA_PRODUCTION_ID=G-XXXXXXXXXX
 
+# GA4 Measurement Protocol API secret — runtime env var written by Ansible at
+# deploy time, NOT a NEXT_PUBLIC_* build arg (that would inline it into the
+# client bundle). One secret per GA4 property: staging and production use
+# different values. Create in GA4 Admin -> Data streams -> [stream] ->
+# Measurement Protocol API secrets.
+GA4_MP_API_SECRET=your_ga4_mp_api_secret_here
+
 # --- Local deploys only (just deploy / scripts/local-deploy.sh) ---
 # GitHub PAT with read:packages, used on the droplet to pull from ghcr.io.
 # The deploy playbooks fail if this is empty.

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -57,6 +57,11 @@ runs:
           exit 1
         fi
 
+        if [[ -z "${GA4_MP_API_SECRET:-}" ]]; then
+          echo "::error::GA4_MP_API_SECRET environment variable is required"
+          exit 1
+        fi
+
         if [[ -z "${RESEND_API_KEY:-}" ]]; then
           echo "::error::RESEND_API_KEY environment variable is required"
           exit 1
@@ -177,6 +182,7 @@ runs:
         BREVO_API_KEY=${BREVO_API_KEY:-}
         STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
         STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET:-}
+        GA4_MP_API_SECRET=${GA4_MP_API_SECRET:-}
         RESEND_API_KEY=${RESEND_API_KEY:-}
         RESEND_FROM_EMAIL=${RESEND_FROM_EMAIL:-}
         WEBMASTER_EMAIL=${WEBMASTER_EMAIL:-}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -520,6 +520,7 @@ jobs:
           BREVO_API_KEY: ${{ secrets.BREVO_API_KEY }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          GA4_MP_API_SECRET: ${{ secrets.GA4_MP_API_SECRET }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL }}
           WEBMASTER_EMAIL: ${{ secrets.WEBMASTER_EMAIL }}

--- a/ansible/production-deploy.yml
+++ b/ansible/production-deploy.yml
@@ -27,6 +27,7 @@
     stripe_secret_key: "{{ STRIPE_SECRET_KEY | default('') }}"
     stripe_publishable_key: "{{ STRIPE_PUBLISHABLE_KEY | default('') }}"
     stripe_webhook_secret: "{{ STRIPE_WEBHOOK_SECRET | default('') }}"
+    ga4_mp_api_secret: "{{ GA4_MP_API_SECRET | default('') }}"
     resend_api_key: "{{ RESEND_API_KEY | default('') }}"
     resend_from_email: "{{ RESEND_FROM_EMAIL | default('') }}"
     webmaster_email: "{{ WEBMASTER_EMAIL | default('') }}"
@@ -484,6 +485,7 @@
           - STRIPE_SECRET_KEY: {{ '✅ SET' if stripe_secret_key else '❌ MISSING' }}
           - STRIPE_PUBLISHABLE_KEY: {{ '✅ SET' if stripe_publishable_key else '❌ MISSING' }}
           - GA_ID: {{ '✅ SET' if ga_id else '❌ MISSING' }} ({{ next_public_environment }})
+          - GA4_MP_API_SECRET: {{ '✅ SET' if ga4_mp_api_secret else '❌ MISSING' }}
           - GITHUB_TOKEN: {{ '✅ SET' if github_token else '❌ MISSING' }}
           - GITHUB_USERNAME: {{ '✅ SET' if github_username else '❌ MISSING' }}
           - GIT_REPO_URL: {{ '✅ SET' if git_repo_url else '❌ MISSING' }}

--- a/ansible/staging-deploy.yml
+++ b/ansible/staging-deploy.yml
@@ -28,6 +28,7 @@
     stripe_secret_key: "{{ STRIPE_SECRET_KEY | default('') }}"
     stripe_publishable_key: "{{ STRIPE_PUBLISHABLE_KEY | default('') }}"
     stripe_webhook_secret: "{{ STRIPE_WEBHOOK_SECRET | default('') }}"
+    ga4_mp_api_secret: "{{ GA4_MP_API_SECRET | default('') }}"
     resend_api_key: "{{ RESEND_API_KEY | default('') }}"
     resend_from_email: "{{ RESEND_FROM_EMAIL | default('') }}"
     webmaster_email: "{{ WEBMASTER_EMAIL | default('') }}"

--- a/ansible/templates/docker-compose.yml.j2
+++ b/ansible/templates/docker-compose.yml.j2
@@ -31,6 +31,7 @@ services:
       - STRIPE_SECRET_KEY={{ stripe_secret_key }}
       - NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY={{ stripe_publishable_key }}
       - STRIPE_WEBHOOK_SECRET={{ stripe_webhook_secret }}
+      - GA4_MP_API_SECRET={{ ga4_mp_api_secret }}
       - BREVO_API_KEY={{ brevo_api_key }}
       - RESEND_API_KEY={{ resend_api_key }}
       - RESEND_FROM_EMAIL={{ resend_from_email }}

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -9,7 +9,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
 
   // Environment tagging for better issue organization
-  environment: process.env.NODE_ENV,
+  environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
 
   // Release tracking for better error grouping and deployment tracking
   release: process.env.NEXT_PUBLIC_COMMIT_HASH,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -8,7 +8,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
 
   // Environment tagging for better issue organization
-  environment: process.env.NODE_ENV,
+  environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
 
   // Release tracking for better error grouping and deployment tracking
   release: process.env.NEXT_PUBLIC_COMMIT_HASH,

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/nextjs";
 import { addBrevoContact, formatE164Phone } from "@/lib/brevo";
 import { sendWebmasterNotification } from "@/lib/notify";
 import { getClientIp, isRateLimited } from "@/lib/rate-limit";
+import { parseGa4CookieIds, sendConversionEvent } from "@/lib/ga4";
 
 function isMissingOrString(value: unknown): value is string | undefined {
   return value === undefined || value === null || typeof value === "string";
@@ -112,6 +113,11 @@ export async function POST(request: Request) {
       );
     }
 
+    // Same-origin fetch from the contact form carries the GA cookies
+    // automatically — no client-side change needed to attribute this lead.
+    const { clientId: gaClientId, sessionId: gaSessionId } =
+      parseGa4CookieIds(request.headers.get("cookie"));
+
     // Validation is done; from here on the lead exists. Brevo (CRM) and the
     // webmaster email (Resend) fire in parallel, and the submission succeeds
     // if either lands — see the redundancy matrix in the PRD.
@@ -155,6 +161,14 @@ export async function POST(request: Request) {
           "Billing cycle": billingCycle || "",
           "Employee count": employeeCount ? employeeCount.toString() : "",
         },
+      }),
+      // sendConversionEvent never throws — it swallows and reports its own
+      // failures — so a Measurement Protocol outage can't affect the
+      // submission outcome below, exactly like the other two settled calls.
+      sendConversionEvent({
+        name: "generate_lead",
+        clientId: gaClientId,
+        sessionId: gaSessionId,
       }),
     ]);
 

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/nextjs";
 import { addBrevoContact, formatE164Phone } from "@/lib/brevo";
 import { sendWebmasterNotification } from "@/lib/notify";
 import { getClientIp, isRateLimited } from "@/lib/rate-limit";
+import { parseGa4CookieIds, sendConversionEvent } from "@/lib/ga4";
 
 // Onboarding leads land in Brevo list 10 (vacated by the old waitlist)
 const ONBOARDING_LIST_ID = 10;
@@ -83,6 +84,11 @@ export async function POST(request: Request) {
       );
     }
 
+    // Same-origin fetch from the onboarding form carries the GA cookies
+    // automatically — no client-side change needed to attribute this signup.
+    const { clientId: gaClientId, sessionId: gaSessionId } =
+      parseGa4CookieIds(request.headers.get("cookie"));
+
     // Validation is done; from here on the lead exists. Brevo (CRM) and the
     // webmaster email (Resend) fire in parallel, and the submission succeeds
     // if either lands — see the redundancy matrix in the PRD.
@@ -127,6 +133,16 @@ export async function POST(request: Request) {
           "Pain points": data.painPoints || "",
           Goals: data.goals || "",
         },
+      }),
+      // sendConversionEvent never throws — it swallows and reports its own
+      // failures — so a Measurement Protocol outage can't affect the
+      // submission outcome below, exactly like the other two settled calls.
+      // No value param: sign_up carries no monetary value, and a placeholder
+      // would inflate Google Ads-imported conversion value.
+      sendConversionEvent({
+        name: "sign_up",
+        clientId: gaClientId,
+        sessionId: gaSessionId,
       }),
     ]);
 

--- a/src/app/api/stripe/create-subscription/route.ts
+++ b/src/app/api/stripe/create-subscription/route.ts
@@ -11,6 +11,13 @@ export const runtime = "nodejs";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+// GA cookies are absent for ad-blocked or consent-declined visitors; treat
+// them as optional and never let a non-string or empty value reach Stripe
+// metadata, which only accepts strings.
+function parseOptionalMetadataString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
 interface CustomerInput {
   name: string;
   email: string;
@@ -89,6 +96,9 @@ export async function POST(request: Request) {
       ? body.idempotencyKey
       : undefined;
 
+  const gaClientId = parseOptionalMetadataString(body?.ga_client_id);
+  const gaSessionId = parseOptionalMetadataString(body?.ga_session_id);
+
   try {
     const priceId = await resolvePriceId({
       plan: order.planName,
@@ -101,6 +111,8 @@ export async function POST(request: Request) {
       billing_cycle: order.billingCycle,
       employee_count: order.employeeCount.toString(),
       company: customer.company,
+      ...(gaClientId ? { ga_client_id: gaClientId } : {}),
+      ...(gaSessionId ? { ga_session_id: gaSessionId } : {}),
     };
 
     // Both creates share the client's idempotency key (with distinct

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -4,6 +4,7 @@ import type Stripe from "stripe";
 import { getServerStripe } from "@/lib/stripe";
 import { addBrevoContact } from "@/lib/brevo";
 import { sendWebmasterNotification } from "@/lib/notify";
+import { sendConversionEvent } from "@/lib/ga4";
 
 // The Stripe SDK will not run on Edge
 export const runtime = "nodejs";
@@ -35,7 +36,15 @@ async function handleNewPaidSubscription(
   const billingCycle = metadata.billing_cycle ?? "";
   const employeeCount = metadata.employee_count ?? "";
   const company = metadata.company ?? "";
+  const gaClientId = metadata.ga_client_id;
+  const gaSessionId = metadata.ga_session_id;
 
+  // sendConversionEvent never throws (it swallows and reports its own
+  // failures), so this settles like the other two even if the MP request
+  // fails — a conversion-tracking outage must never fail the webhook or
+  // trigger a Stripe retry. Invoice id is the transaction_id: stable across
+  // a webhook redelivery for the same invoice, so GA4 dedupes the event
+  // rather than double-counting revenue.
   const [brevoSettled, notifySettled] = await Promise.allSettled([
     email
       ? addBrevoContact({
@@ -67,6 +76,16 @@ async function handleNewPaidSubscription(
           invoice.currency ?? "cad",
         ),
         Invoice: invoice.id ?? "",
+      },
+    }),
+    sendConversionEvent({
+      name: "purchase",
+      clientId: gaClientId,
+      sessionId: gaSessionId,
+      params: {
+        transaction_id: invoice.id ?? "",
+        value: invoice.amount_paid / 100,
+        currency: (invoice.currency ?? "cad").toUpperCase(),
       },
     }),
   ]);

--- a/src/app/components/StripeWrapper.tsx
+++ b/src/app/components/StripeWrapper.tsx
@@ -3,6 +3,7 @@
 import { ReactNode, useEffect, useMemo, useState } from "react";
 import { Elements } from "@stripe/react-stripe-js";
 import { getStripe } from "../../lib/stripe";
+import { parseGa4CookieIds } from "../../lib/ga4Cookies";
 
 export interface CheckoutCustomer {
   name: string;
@@ -48,6 +49,13 @@ export default function StripeWrapper({
         setLoading(true);
         setError(null);
 
+        // Read synchronously from document.cookie rather than the async
+        // gtag('get', ...) callback: if that callback hasn't fired by
+        // submit time, the identifier would be silently lost. Absent
+        // cookies (ad blocker, consent declined) just omit the fields below.
+        const { clientId: gaClientId, sessionId: gaSessionId } =
+          parseGa4CookieIds(document.cookie);
+
         // The server resolves the price from these order details;
         // no amount is sent from the client.
         const response = await fetch("/api/stripe/create-subscription", {
@@ -59,6 +67,8 @@ export default function StripeWrapper({
             billingCycle,
             customer,
             idempotencyKey,
+            ...(gaClientId ? { ga_client_id: gaClientId } : {}),
+            ...(gaSessionId ? { ga_session_id: gaSessionId } : {}),
           }),
         });
 

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -8,7 +8,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
 
   // Environment tagging for better issue organization
-  environment: process.env.NODE_ENV,
+  environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
 
   // Release tracking for better error grouping and deployment tracking
   release: process.env.NEXT_PUBLIC_COMMIT_HASH,

--- a/src/lib/ga4.ts
+++ b/src/lib/ga4.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { resolveGa4Environment, resolveGa4MeasurementId } from "./ga4Cookies";
 
 /**
  * Server-side GA4 Measurement Protocol sender.
@@ -11,75 +12,11 @@ const MP_ENDPOINT = "https://www.google-analytics.com/mp/collect";
 const MP_DEBUG_ENDPOINT = "https://www.google-analytics.com/debug/mp/collect";
 const MP_TIMEOUT_MS = 5000;
 
-type Ga4Environment = "production" | "staging" | "development";
-
-function resolveEnvironment(): Ga4Environment {
-  if (process.env.NEXT_PUBLIC_ENVIRONMENT === "production") return "production";
-  if (process.env.NEXT_PUBLIC_ENVIRONMENT === "staging") return "staging";
-  return "development";
-}
-
-function resolveGa4MeasurementId(environment: Ga4Environment): string | undefined {
-  switch (environment) {
-    case "production":
-      return process.env.NEXT_PUBLIC_PRODUCTION_GA_ID;
-    case "staging":
-      return process.env.NEXT_PUBLIC_STAGING_GA_ID;
-    default:
-      return process.env.NEXT_PUBLIC_DEV_GA_ID;
-  }
-}
-
-/**
- * Extract client_id (from `_ga`) and session_id (from `_ga_<CONTAINER_ID>`)
- * out of a raw `Cookie` request header. The container ID is derived from the
- * measurement ID at runtime since it differs per environment.
- *
- * Never throws: any cookie that's absent or doesn't match the expected shape
- * simply yields an undefined field.
- */
-export function parseGa4CookieIds(
-  cookieHeader: string | undefined | null,
-  measurementId: string | undefined = resolveGa4MeasurementId(resolveEnvironment()),
-): { clientId?: string; sessionId?: string } {
-  if (!cookieHeader) return {};
-
-  const cookies = new Map<string, string>();
-  for (const pair of cookieHeader.split(";")) {
-    const separatorIndex = pair.indexOf("=");
-    if (separatorIndex === -1) continue;
-    const name = pair.slice(0, separatorIndex).trim();
-    const value = pair.slice(separatorIndex + 1).trim();
-    if (name) cookies.set(name, value);
-  }
-
-  // `_ga` looks like GA1.1.<part1>.<part2>; client_id is the last two segments.
-  let clientId: string | undefined;
-  const gaCookie = cookies.get("_ga");
-  if (gaCookie) {
-    const segments = gaCookie.split(".");
-    if (segments.length >= 2) {
-      clientId = segments.slice(-2).join(".");
-    }
-  }
-
-  // `_ga_<CONTAINER_ID>` looks like GS1.1.<session_id>.<...>; session_id is
-  // the third segment. The container ID is the measurement ID minus its
-  // leading "G-".
-  let sessionId: string | undefined;
-  if (measurementId) {
-    const containerId = measurementId.replace(/^G-/, "");
-    const sessionCookie = cookies.get(`_ga_${containerId}`);
-    if (sessionCookie) {
-      const segments = sessionCookie.split(".");
-      if (segments.length >= 3 && segments[2]) {
-        sessionId = segments[2];
-      }
-    }
-  }
-
-  return { clientId, sessionId };
-}
+// Re-exported so existing callers of the sender module can still reach the
+// cookie parser without knowing it moved to ga4Cookies.ts. Client code
+// (checkout) should import it from ga4Cookies.ts directly instead, to avoid
+// pulling this Sentry-importing module into the browser bundle.
+export { parseGa4CookieIds } from "./ga4Cookies";
 
 /**
  * Derive a stable fallback client_id when no `_ga` cookie is available
@@ -106,7 +43,7 @@ export async function sendConversionEvent({
   sessionId?: string;
   params?: Record<string, unknown>;
 }): Promise<void> {
-  const environment = resolveEnvironment();
+  const environment = resolveGa4Environment();
   const measurementId = resolveGa4MeasurementId(environment);
   const apiSecret = process.env.GA4_MP_API_SECRET;
 

--- a/src/lib/ga4.ts
+++ b/src/lib/ga4.ts
@@ -1,0 +1,185 @@
+import * as Sentry from "@sentry/nextjs";
+
+/**
+ * Server-side GA4 Measurement Protocol sender.
+ *
+ * Deliberately does not import gtag.ts: that module logs at module scope,
+ * which would fire on every server request if pulled in here.
+ */
+
+const MP_ENDPOINT = "https://www.google-analytics.com/mp/collect";
+const MP_DEBUG_ENDPOINT = "https://www.google-analytics.com/debug/mp/collect";
+const MP_TIMEOUT_MS = 5000;
+
+type Ga4Environment = "production" | "staging" | "development";
+
+function resolveEnvironment(): Ga4Environment {
+  if (process.env.NEXT_PUBLIC_ENVIRONMENT === "production") return "production";
+  if (process.env.NEXT_PUBLIC_ENVIRONMENT === "staging") return "staging";
+  return "development";
+}
+
+function resolveGa4MeasurementId(environment: Ga4Environment): string | undefined {
+  switch (environment) {
+    case "production":
+      return process.env.NEXT_PUBLIC_PRODUCTION_GA_ID;
+    case "staging":
+      return process.env.NEXT_PUBLIC_STAGING_GA_ID;
+    default:
+      return process.env.NEXT_PUBLIC_DEV_GA_ID;
+  }
+}
+
+/**
+ * Extract client_id (from `_ga`) and session_id (from `_ga_<CONTAINER_ID>`)
+ * out of a raw `Cookie` request header. The container ID is derived from the
+ * measurement ID at runtime since it differs per environment.
+ *
+ * Never throws: any cookie that's absent or doesn't match the expected shape
+ * simply yields an undefined field.
+ */
+export function parseGa4CookieIds(
+  cookieHeader: string | undefined | null,
+  measurementId: string | undefined = resolveGa4MeasurementId(resolveEnvironment()),
+): { clientId?: string; sessionId?: string } {
+  if (!cookieHeader) return {};
+
+  const cookies = new Map<string, string>();
+  for (const pair of cookieHeader.split(";")) {
+    const separatorIndex = pair.indexOf("=");
+    if (separatorIndex === -1) continue;
+    const name = pair.slice(0, separatorIndex).trim();
+    const value = pair.slice(separatorIndex + 1).trim();
+    if (name) cookies.set(name, value);
+  }
+
+  // `_ga` looks like GA1.1.<part1>.<part2>; client_id is the last two segments.
+  let clientId: string | undefined;
+  const gaCookie = cookies.get("_ga");
+  if (gaCookie) {
+    const segments = gaCookie.split(".");
+    if (segments.length >= 2) {
+      clientId = segments.slice(-2).join(".");
+    }
+  }
+
+  // `_ga_<CONTAINER_ID>` looks like GS1.1.<session_id>.<...>; session_id is
+  // the third segment. The container ID is the measurement ID minus its
+  // leading "G-".
+  let sessionId: string | undefined;
+  if (measurementId) {
+    const containerId = measurementId.replace(/^G-/, "");
+    const sessionCookie = cookies.get(`_ga_${containerId}`);
+    if (sessionCookie) {
+      const segments = sessionCookie.split(".");
+      if (segments.length >= 3 && segments[2]) {
+        sessionId = segments[2];
+      }
+    }
+  }
+
+  return { clientId, sessionId };
+}
+
+/**
+ * Derive a stable fallback client_id when no `_ga` cookie is available
+ * (e.g. a server-to-server webhook has no browser cookies at all). Built
+ * from a caller-supplied seed such as a Stripe invoice ID — deterministic,
+ * so retries land on the same GA4 user instead of minting a new one.
+ */
+export function deriveGa4FallbackClientId(seed: string): string {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) >>> 0;
+  }
+  return `fallback.${hash}`;
+}
+
+export async function sendConversionEvent({
+  name,
+  clientId,
+  sessionId,
+  params,
+}: {
+  name: string;
+  clientId: string | undefined;
+  sessionId?: string;
+  params?: Record<string, unknown>;
+}): Promise<void> {
+  const environment = resolveEnvironment();
+  const measurementId = resolveGa4MeasurementId(environment);
+  const apiSecret = process.env.GA4_MP_API_SECRET;
+
+  if (!measurementId) {
+    console.error(`GA4 measurement ID missing (${environment}); dropping "${name}" conversion`);
+    return;
+  }
+
+  if (!apiSecret) {
+    // Missing in dev is expected (no secret exists locally) and must stay
+    // silent — throwing or logging here would just add noise to local runs.
+    if (environment === "development") return;
+
+    const message = `GA4 MP API secret missing (${environment}); dropping "${name}" conversion`;
+    console.error(message);
+    Sentry.captureMessage(message, "error");
+    return;
+  }
+
+  if (!clientId) {
+    // Expected on every ad-blocked visitor — not exceptional, so this stays
+    // a console.log rather than a Sentry alert that would bury real issues.
+    console.log(`GA4 client_id missing; dropping "${name}" conversion`);
+    return;
+  }
+
+  const endpoint = environment === "production" ? MP_ENDPOINT : MP_DEBUG_ENDPOINT;
+  const url = `${endpoint}?measurement_id=${encodeURIComponent(measurementId)}&api_secret=${encodeURIComponent(apiSecret)}`;
+
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => abortController.abort(), MP_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_id: clientId,
+        events: [
+          {
+            name,
+            params: {
+              ...(sessionId ? { session_id: sessionId } : {}),
+              ...params,
+            },
+          },
+        ],
+      }),
+      signal: abortController.signal,
+    });
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const message = `GA4 MP request failed: ${response.status} (event "${name}")`;
+      console.error(message);
+      Sentry.captureMessage(message, "error");
+      return;
+    }
+
+    if (environment !== "production") {
+      const body = (await response.json().catch(() => null)) as {
+        validationMessages?: unknown[];
+      } | null;
+      if (body?.validationMessages && body.validationMessages.length > 0) {
+        const message = `GA4 MP validation errors for "${name}": ${JSON.stringify(body.validationMessages)}`;
+        console.error(message);
+        Sentry.captureMessage(message, "error");
+      }
+    }
+  } catch (error) {
+    clearTimeout(timeoutId);
+    const message = `GA4 MP request threw (event "${name}"): ${error instanceof Error ? error.message : String(error)}`;
+    console.error(message);
+    Sentry.captureMessage(message, "error");
+  }
+}

--- a/src/lib/ga4Cookies.ts
+++ b/src/lib/ga4Cookies.ts
@@ -1,0 +1,82 @@
+/**
+ * GA4 cookie/environment helpers shared by server and client code.
+ *
+ * Kept separate from ga4.ts (the Measurement Protocol sender, which imports
+ * Sentry and only makes sense server-side) so client code — like checkout,
+ * which needs to read these cookies synchronously before submitting — can
+ * import this module without pulling server-only code into the bundle.
+ */
+
+type Ga4Environment = "production" | "staging" | "development";
+
+export function resolveGa4Environment(): Ga4Environment {
+  if (process.env.NEXT_PUBLIC_ENVIRONMENT === "production") return "production";
+  if (process.env.NEXT_PUBLIC_ENVIRONMENT === "staging") return "staging";
+  return "development";
+}
+
+export function resolveGa4MeasurementId(
+  environment: Ga4Environment = resolveGa4Environment(),
+): string | undefined {
+  switch (environment) {
+    case "production":
+      return process.env.NEXT_PUBLIC_PRODUCTION_GA_ID;
+    case "staging":
+      return process.env.NEXT_PUBLIC_STAGING_GA_ID;
+    default:
+      return process.env.NEXT_PUBLIC_DEV_GA_ID;
+  }
+}
+
+/**
+ * Extract client_id (from `_ga`) and session_id (from `_ga_<CONTAINER_ID>`)
+ * out of a raw cookie string — either a request `Cookie` header (server) or
+ * `document.cookie` (browser); both use the same `name=value; name=value`
+ * shape. The container ID is derived from the measurement ID at runtime
+ * since it differs per environment.
+ *
+ * Never throws: any cookie that's absent or doesn't match the expected shape
+ * simply yields an undefined field.
+ */
+export function parseGa4CookieIds(
+  cookieHeader: string | undefined | null,
+  measurementId: string | undefined = resolveGa4MeasurementId(),
+): { clientId?: string; sessionId?: string } {
+  if (!cookieHeader) return {};
+
+  const cookies = new Map<string, string>();
+  for (const pair of cookieHeader.split(";")) {
+    const separatorIndex = pair.indexOf("=");
+    if (separatorIndex === -1) continue;
+    const name = pair.slice(0, separatorIndex).trim();
+    const value = pair.slice(separatorIndex + 1).trim();
+    if (name) cookies.set(name, value);
+  }
+
+  // `_ga` looks like GA1.1.<part1>.<part2>; client_id is the last two segments.
+  let clientId: string | undefined;
+  const gaCookie = cookies.get("_ga");
+  if (gaCookie) {
+    const segments = gaCookie.split(".");
+    if (segments.length >= 2) {
+      clientId = segments.slice(-2).join(".");
+    }
+  }
+
+  // `_ga_<CONTAINER_ID>` looks like GS1.1.<session_id>.<...>; session_id is
+  // the third segment. The container ID is the measurement ID minus its
+  // leading "G-".
+  let sessionId: string | undefined;
+  if (measurementId) {
+    const containerId = measurementId.replace(/^G-/, "");
+    const sessionCookie = cookies.get(`_ga_${containerId}`);
+    if (sessionCookie) {
+      const segments = sessionCookie.split(".");
+      if (segments.length >= 3 && segments[2]) {
+        sessionId = segments[2];
+      }
+    }
+  }
+
+  return { clientId, sessionId };
+}

--- a/src/tests/StripeWrapper.test.tsx
+++ b/src/tests/StripeWrapper.test.tsx
@@ -26,6 +26,12 @@ describe("StripeWrapper", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    document.cookie.split(";").forEach((c) => {
+      const name = c.split("=")[0]?.trim();
+      if (name) {
+        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+      }
+    });
   });
 
   afterAll(() => {
@@ -108,6 +114,71 @@ describe("StripeWrapper", () => {
 
     // Verify getStripe was called
     expect(getStripe).toHaveBeenCalled();
+  });
+
+  it("includes ga_client_id and ga_session_id when both GA cookies are present", async () => {
+    const originalEnv = process.env.NEXT_PUBLIC_DEV_GA_ID;
+    process.env.NEXT_PUBLIC_DEV_GA_ID = "G-TESTID";
+    document.cookie = "_ga=GA1.1.111111111.222222222";
+    document.cookie = "_ga_TESTID=GS1.1.333333333.4.1.444444444.0.0.0";
+
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ clientSecret: "test_secret" }),
+    } as unknown as Response);
+
+    render(<StripeWrapper {...orderProps}>{mockChildComponent}</StripeWrapper>);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stripe-elements")).toBeInTheDocument();
+    });
+
+    expect(lastFetchBody()).toEqual(
+      expect.objectContaining({
+        ga_client_id: "111111111.222222222",
+        ga_session_id: "333333333",
+      }),
+    );
+
+    process.env.NEXT_PUBLIC_DEV_GA_ID = originalEnv;
+  });
+
+  it("omits ga_client_id and ga_session_id from the request when both GA cookies are absent", async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ clientSecret: "test_secret" }),
+    } as unknown as Response);
+
+    render(<StripeWrapper {...orderProps}>{mockChildComponent}</StripeWrapper>);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stripe-elements")).toBeInTheDocument();
+    });
+
+    const body = lastFetchBody();
+    expect(body).not.toHaveProperty("ga_client_id");
+    expect(body).not.toHaveProperty("ga_session_id");
+  });
+
+  it("includes only ga_client_id when the session cookie is absent", async () => {
+    document.cookie = "_ga=GA1.1.111111111.222222222";
+
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ clientSecret: "test_secret" }),
+    } as unknown as Response);
+
+    render(<StripeWrapper {...orderProps}>{mockChildComponent}</StripeWrapper>);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stripe-elements")).toBeInTheDocument();
+    });
+
+    const body = lastFetchBody();
+    expect(body).toEqual(
+      expect.objectContaining({ ga_client_id: "111111111.222222222" }),
+    );
+    expect(body).not.toHaveProperty("ga_session_id");
   });
 
   it("sends the order details for a different plan and billing cycle", async () => {

--- a/src/tests/api-contact.test.ts
+++ b/src/tests/api-contact.test.ts
@@ -5,6 +5,7 @@ import * as Sentry from "@sentry/nextjs";
 import { addBrevoContact } from "@/lib/brevo";
 import { sendWebmasterNotification } from "@/lib/notify";
 import { resetRateLimits } from "@/lib/rate-limit";
+import { sendConversionEvent } from "@/lib/ga4";
 
 // Mock next/server
 jest.mock("next/server", () => ({
@@ -25,14 +26,20 @@ jest.mock("@/lib/brevo", () => ({
 jest.mock("@/lib/notify", () => ({
   sendWebmasterNotification: jest.fn(),
 }));
+// Keep the real cookie parser; only the network-calling sender is mocked
+jest.mock("@/lib/ga4", () => ({
+  ...jest.requireActual("@/lib/ga4"),
+  sendConversionEvent: jest.fn(),
+}));
 
 const mockBrevo = addBrevoContact as jest.Mock;
 const mockNotify = sendWebmasterNotification as jest.Mock;
+const mockSendConversionEvent = sendConversionEvent as jest.Mock;
 
-function buildRequest(body: unknown): Request {
+function buildRequest(body: unknown, headers?: Record<string, string>): Request {
   return {
     json: jest.fn().mockResolvedValue(body),
-    headers: new Headers({ "x-forwarded-for": "203.0.113.7" }),
+    headers: new Headers({ "x-forwarded-for": "203.0.113.7", ...headers }),
   } as unknown as Request;
 }
 
@@ -48,6 +55,7 @@ describe("Contact API Route", () => {
     resetRateLimits();
     mockBrevo.mockResolvedValue({ ok: true });
     mockNotify.mockResolvedValue(true);
+    mockSendConversionEvent.mockResolvedValue(undefined);
   });
 
   it("returns 400 if email is missing", async () => {
@@ -131,6 +139,52 @@ describe("Contact API Route", () => {
       }),
     });
     expect(NextResponse.json).toHaveBeenCalledWith({ success: true });
+  });
+
+  it("sends a generate_lead conversion attributed from the request cookies", async () => {
+    const originalGaId = process.env.NEXT_PUBLIC_DEV_GA_ID;
+    process.env.NEXT_PUBLIC_DEV_GA_ID = "G-TESTID";
+
+    await POST(
+      buildRequest(validBody, {
+        cookie:
+          "_ga=GA1.1.111111111.222222222; _ga_TESTID=GS1.1.333333333.4.1.444444444.0.0.0",
+      }),
+    );
+
+    expect(mockSendConversionEvent).toHaveBeenCalledWith({
+      name: "generate_lead",
+      clientId: "111111111.222222222",
+      sessionId: "333333333",
+    });
+    expect(NextResponse.json).toHaveBeenCalledWith({ success: true });
+
+    process.env.NEXT_PUBLIC_DEV_GA_ID = originalGaId;
+  });
+
+  it("still succeeds and sends no event when there are no GA cookies", async () => {
+    await POST(buildRequest(validBody));
+
+    expect(mockSendConversionEvent).toHaveBeenCalledWith({
+      name: "generate_lead",
+      clientId: undefined,
+      sessionId: undefined,
+    });
+    expect(NextResponse.json).toHaveBeenCalledWith({ success: true });
+  });
+
+  it("does not fail the submission when the conversion event rejects", async () => {
+    mockSendConversionEvent.mockRejectedValueOnce(new Error("MP request failed"));
+
+    await POST(buildRequest(validBody));
+
+    expect(NextResponse.json).toHaveBeenCalledWith({ success: true });
+  });
+
+  it("sends no conversion event when validation fails", async () => {
+    await POST(buildRequest({ name: "Test User", phone: "123-456-7890" }));
+
+    expect(mockSendConversionEvent).not.toHaveBeenCalled();
   });
 
   it("does not send an IS_WAITLIST attribute", async () => {
@@ -221,6 +275,7 @@ describe("Contact API Route", () => {
     expect(NextResponse.json).toHaveBeenCalledWith({ success: true });
     expect(mockBrevo).not.toHaveBeenCalled();
     expect(mockNotify).not.toHaveBeenCalled();
+    expect(mockSendConversionEvent).not.toHaveBeenCalled();
   });
 
   it("rate limits the sixth submission from one IP", async () => {

--- a/src/tests/api-onboarding.test.ts
+++ b/src/tests/api-onboarding.test.ts
@@ -5,6 +5,7 @@ import * as Sentry from "@sentry/nextjs";
 import { addBrevoContact } from "@/lib/brevo";
 import { sendWebmasterNotification } from "@/lib/notify";
 import { resetRateLimits } from "@/lib/rate-limit";
+import { sendConversionEvent } from "@/lib/ga4";
 
 // Mock next/server
 jest.mock("next/server", () => ({
@@ -25,9 +26,15 @@ jest.mock("@/lib/brevo", () => ({
 jest.mock("@/lib/notify", () => ({
   sendWebmasterNotification: jest.fn(),
 }));
+// Keep the real cookie parser; only the network-calling sender is mocked
+jest.mock("@/lib/ga4", () => ({
+  ...jest.requireActual("@/lib/ga4"),
+  sendConversionEvent: jest.fn(),
+}));
 
 const mockBrevo = addBrevoContact as jest.Mock;
 const mockNotify = sendWebmasterNotification as jest.Mock;
+const mockSendConversionEvent = sendConversionEvent as jest.Mock;
 
 const validOnboardingData = {
   companyName: "Test Company",
@@ -46,10 +53,10 @@ const validOnboardingData = {
   goals: "Some goals",
 };
 
-function buildRequest(body: unknown): Request {
+function buildRequest(body: unknown, headers?: Record<string, string>): Request {
   return {
     json: jest.fn().mockResolvedValue(body),
-    headers: new Headers({ "x-forwarded-for": "203.0.113.9" }),
+    headers: new Headers({ "x-forwarded-for": "203.0.113.9", ...headers }),
   } as unknown as Request;
 }
 
@@ -59,6 +66,7 @@ describe("Onboarding API Route", () => {
     resetRateLimits();
     mockBrevo.mockResolvedValue({ ok: true });
     mockNotify.mockResolvedValue(true);
+    mockSendConversionEvent.mockResolvedValue(undefined);
   });
 
   it("persists the lead to Brevo list 10 and emails the webmaster", async () => {
@@ -88,6 +96,66 @@ describe("Onboarding API Route", () => {
       success: true,
       message: "Onboarding data received successfully",
     });
+  });
+
+  it("sends a sign_up conversion with no value, attributed from the request cookies", async () => {
+    const originalGaId = process.env.NEXT_PUBLIC_DEV_GA_ID;
+    process.env.NEXT_PUBLIC_DEV_GA_ID = "G-TESTID";
+
+    await POST(
+      buildRequest(validOnboardingData, {
+        cookie:
+          "_ga=GA1.1.111111111.222222222; _ga_TESTID=GS1.1.333333333.4.1.444444444.0.0.0",
+      }),
+    );
+
+    expect(mockSendConversionEvent).toHaveBeenCalledWith({
+      name: "sign_up",
+      clientId: "111111111.222222222",
+      sessionId: "333333333",
+    });
+    expect(mockSendConversionEvent.mock.calls[0][0]).not.toHaveProperty(
+      "params",
+    );
+    expect(NextResponse.json).toHaveBeenCalledWith({
+      success: true,
+      message: "Onboarding data received successfully",
+    });
+
+    process.env.NEXT_PUBLIC_DEV_GA_ID = originalGaId;
+  });
+
+  it("still succeeds and sends no event when there are no GA cookies", async () => {
+    await POST(buildRequest(validOnboardingData));
+
+    expect(mockSendConversionEvent).toHaveBeenCalledWith({
+      name: "sign_up",
+      clientId: undefined,
+      sessionId: undefined,
+    });
+    expect(NextResponse.json).toHaveBeenCalledWith({
+      success: true,
+      message: "Onboarding data received successfully",
+    });
+  });
+
+  it("does not fail the submission when the conversion event rejects", async () => {
+    mockSendConversionEvent.mockRejectedValueOnce(new Error("MP request failed"));
+
+    await POST(buildRequest(validOnboardingData));
+
+    expect(NextResponse.json).toHaveBeenCalledWith({
+      success: true,
+      message: "Onboarding data received successfully",
+    });
+  });
+
+  it("sends no conversion event when validation fails", async () => {
+    await POST(
+      buildRequest({ companyName: "Test Company", industry: "Technology" }),
+    );
+
+    expect(mockSendConversionEvent).not.toHaveBeenCalled();
   });
 
   it("returns 400 when required fields are missing", async () => {
@@ -182,6 +250,7 @@ describe("Onboarding API Route", () => {
     expect(NextResponse.json).toHaveBeenCalledWith({ success: true });
     expect(mockBrevo).not.toHaveBeenCalled();
     expect(mockNotify).not.toHaveBeenCalled();
+    expect(mockSendConversionEvent).not.toHaveBeenCalled();
   });
 
   it("rate limits the sixth submission from one IP", async () => {

--- a/src/tests/api-stripe-create-subscription.test.ts
+++ b/src/tests/api-stripe-create-subscription.test.ts
@@ -133,6 +133,61 @@ describe("POST /api/stripe/create-subscription", () => {
     expect(response.data).toEqual({ clientSecret: "test_client_secret" });
   });
 
+  it("threads ga_client_id and ga_session_id into subscription metadata when both are present", async () => {
+    await POST(
+      buildRequest({
+        ...validBody,
+        ga_client_id: "111111111.222222222",
+        ga_session_id: "333333333",
+      }),
+    );
+
+    const [params] = mockSubscriptionsCreate.mock.calls[0];
+    expect(params.metadata).toEqual({
+      plan: "basic",
+      billing_cycle: "monthly",
+      employee_count: "5",
+      company: "Test Co",
+      ga_client_id: "111111111.222222222",
+      ga_session_id: "333333333",
+    });
+  });
+
+  it("omits ga_client_id and ga_session_id from metadata when both are absent", async () => {
+    await POST(buildRequest(validBody));
+
+    const [params] = mockSubscriptionsCreate.mock.calls[0];
+    expect(params.metadata).not.toHaveProperty("ga_client_id");
+    expect(params.metadata).not.toHaveProperty("ga_session_id");
+  });
+
+  it("threads only the identifier that is present when just one GA cookie was available", async () => {
+    await POST(
+      buildRequest({
+        ...validBody,
+        ga_client_id: "111111111.222222222",
+      }),
+    );
+
+    const [params] = mockSubscriptionsCreate.mock.calls[0];
+    expect(params.metadata).toMatchObject({ ga_client_id: "111111111.222222222" });
+    expect(params.metadata).not.toHaveProperty("ga_session_id");
+  });
+
+  it("never lets a non-string or empty ga identifier reach Stripe metadata", async () => {
+    await POST(
+      buildRequest({
+        ...validBody,
+        ga_client_id: 12345,
+        ga_session_id: "   ",
+      }),
+    );
+
+    const [params] = mockSubscriptionsCreate.mock.calls[0];
+    expect(params.metadata).not.toHaveProperty("ga_client_id");
+    expect(params.metadata).not.toHaveProperty("ga_session_id");
+  });
+
   it("never accepts a client-supplied amount or price", async () => {
     await POST(
       buildRequest({

--- a/src/tests/api-stripe-webhook.test.ts
+++ b/src/tests/api-stripe-webhook.test.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { addBrevoContact } from "@/lib/brevo";
 import { sendWebmasterNotification } from "@/lib/notify";
+import { sendConversionEvent } from "@/lib/ga4";
 
 jest.mock("next/server", () => ({
   NextResponse: {
@@ -29,9 +30,13 @@ jest.mock("@/lib/brevo", () => ({
 jest.mock("@/lib/notify", () => ({
   sendWebmasterNotification: jest.fn(),
 }));
+jest.mock("@/lib/ga4", () => ({
+  sendConversionEvent: jest.fn(),
+}));
 
 const mockBrevo = addBrevoContact as jest.Mock;
 const mockNotify = sendWebmasterNotification as jest.Mock;
+const mockSendConversionEvent = sendConversionEvent as jest.Mock;
 
 const originalEnv = process.env;
 
@@ -68,12 +73,26 @@ const paidInvoice = {
   },
 };
 
+const paidInvoiceWithGaIds = {
+  ...paidInvoice,
+  parent: {
+    subscription_details: {
+      metadata: {
+        ...paidInvoice.parent.subscription_details.metadata,
+        ga_client_id: "111111111.222222222",
+        ga_session_id: "333333333",
+      },
+    },
+  },
+};
+
 describe("POST /api/stripe/webhook", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env = { ...originalEnv, STRIPE_WEBHOOK_SECRET: "whsec_test" };
     mockBrevo.mockResolvedValue({ ok: true });
     mockNotify.mockResolvedValue(true);
+    mockSendConversionEvent.mockResolvedValue(undefined);
     mockConstructEvent.mockReturnValue({
       type: "invoice.payment_succeeded",
       data: { object: paidInvoice },
@@ -153,6 +172,49 @@ describe("POST /api/stripe/webhook", () => {
     expect(NextResponse.json).toHaveBeenCalledWith({ received: true });
   });
 
+  it("sends a purchase conversion event carrying the GA identifiers, value, and currency", async () => {
+    mockConstructEvent.mockReturnValueOnce({
+      type: "invoice.payment_succeeded",
+      data: { object: paidInvoiceWithGaIds },
+    });
+
+    await POST(buildRequest());
+
+    expect(mockSendConversionEvent).toHaveBeenCalledWith({
+      name: "purchase",
+      clientId: "111111111.222222222",
+      sessionId: "333333333",
+      params: {
+        transaction_id: "in_123",
+        value: 495,
+        currency: "CAD",
+      },
+    });
+    expect(NextResponse.json).toHaveBeenCalledWith({ received: true });
+  });
+
+  it("still calls the conversion sender (which no-ops and logs) when GA identifiers are absent", async () => {
+    await POST(buildRequest());
+
+    expect(mockSendConversionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: undefined,
+        sessionId: undefined,
+      }),
+    );
+    expect(NextResponse.json).toHaveBeenCalledWith({ received: true });
+  });
+
+  it("does not fail the webhook or the other side effects when the conversion event rejects", async () => {
+    mockSendConversionEvent.mockRejectedValueOnce(new Error("MP request failed"));
+
+    await POST(buildRequest());
+
+    expect(mockBrevo).toHaveBeenCalled();
+    expect(mockNotify).toHaveBeenCalled();
+    expect(NextResponse.json).toHaveBeenCalledWith({ received: true });
+  });
+
   it("ignores renewal invoices", async () => {
     mockConstructEvent.mockReturnValueOnce({
       type: "invoice.payment_succeeded",
@@ -165,6 +227,7 @@ describe("POST /api/stripe/webhook", () => {
 
     expect(mockBrevo).not.toHaveBeenCalled();
     expect(mockNotify).not.toHaveBeenCalled();
+    expect(mockSendConversionEvent).not.toHaveBeenCalled();
     expect(NextResponse.json).toHaveBeenCalledWith({ received: true });
   });
 
@@ -178,6 +241,7 @@ describe("POST /api/stripe/webhook", () => {
 
     expect(mockBrevo).not.toHaveBeenCalled();
     expect(mockNotify).not.toHaveBeenCalled();
+    expect(mockSendConversionEvent).not.toHaveBeenCalled();
     expect(NextResponse.json).toHaveBeenCalledWith({ received: true });
   });
 

--- a/src/tests/ga4.lib.test.ts
+++ b/src/tests/ga4.lib.test.ts
@@ -1,0 +1,242 @@
+import * as Sentry from "@sentry/nextjs";
+import {
+  parseGa4CookieIds,
+  deriveGa4FallbackClientId,
+  sendConversionEvent,
+} from "@/lib/ga4";
+
+jest.mock("@sentry/nextjs", () => ({
+  captureMessage: jest.fn(),
+}));
+
+const mockCaptureMessage = Sentry.captureMessage as jest.Mock;
+const originalEnv = process.env;
+
+describe("parseGa4CookieIds", () => {
+  const measurementId = "G-ABC123XYZ";
+
+  it("extracts client_id and session_id from well-formed cookies", () => {
+    const cookieHeader =
+      "_ga=GA1.1.111111111.222222222; _ga_ABC123XYZ=GS1.1.333333333.4.1.444444444.0.0.0";
+
+    expect(parseGa4CookieIds(cookieHeader, measurementId)).toEqual({
+      clientId: "111111111.222222222",
+      sessionId: "333333333",
+    });
+  });
+
+  it("returns an empty object when the cookie header is absent", () => {
+    expect(parseGa4CookieIds(undefined, measurementId)).toEqual({});
+    expect(parseGa4CookieIds(null, measurementId)).toEqual({});
+  });
+
+  it("yields undefined identifiers for cookies that don't match the expected shape", () => {
+    const cookieHeader = "_ga=malformed; _ga_ABC123XYZ=alsomalformed";
+
+    expect(parseGa4CookieIds(cookieHeader, measurementId)).toEqual({});
+  });
+
+  it("yields undefined identifiers when the relevant cookies are simply missing", () => {
+    const cookieHeader = "other_cookie=value";
+
+    expect(parseGa4CookieIds(cookieHeader, measurementId)).toEqual({});
+  });
+
+  it("ignores cookie pairs without an '=' instead of throwing", () => {
+    const cookieHeader = "garbage; _ga=GA1.1.111111111.222222222";
+
+    expect(parseGa4CookieIds(cookieHeader, measurementId)).toEqual({
+      clientId: "111111111.222222222",
+    });
+  });
+
+  it("skips session_id resolution when no measurement ID is available", () => {
+    const cookieHeader = "_ga_ABC123XYZ=GS1.1.333333333.4.1.444444444.0.0.0";
+
+    expect(parseGa4CookieIds(cookieHeader, undefined)).toEqual({});
+  });
+
+  it("resolves the measurement ID itself when none is passed", () => {
+    process.env = { ...originalEnv, NEXT_PUBLIC_ENVIRONMENT: "development" };
+    expect(() => parseGa4CookieIds("_ga=GA1.1.1.2")).not.toThrow();
+    process.env = originalEnv;
+  });
+
+  it("derives the session cookie name from the measurement ID at runtime", () => {
+    const cookieHeader =
+      "_ga_DIFFERENT=GS1.1.999999999.1.1.999999999.0.0.0";
+
+    // Cookie name built from a different measurement ID than the one that
+    // produced this cookie, so it should not match.
+    expect(parseGa4CookieIds(cookieHeader, measurementId).sessionId).toBeUndefined();
+
+    expect(
+      parseGa4CookieIds(cookieHeader, "G-DIFFERENT").sessionId,
+    ).toBe("999999999");
+  });
+});
+
+describe("deriveGa4FallbackClientId", () => {
+  it("is deterministic for the same seed", () => {
+    expect(deriveGa4FallbackClientId("invoice_123")).toBe(
+      deriveGa4FallbackClientId("invoice_123"),
+    );
+  });
+
+  it("differs across seeds", () => {
+    expect(deriveGa4FallbackClientId("invoice_123")).not.toBe(
+      deriveGa4FallbackClientId("invoice_456"),
+    );
+  });
+});
+
+describe("sendConversionEvent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_ENVIRONMENT: "staging",
+      NEXT_PUBLIC_STAGING_GA_ID: "G-STAGINGID",
+      GA4_MP_API_SECRET: "test-secret",
+    };
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ validationMessages: [] }),
+      }),
+    ) as jest.Mock;
+    console.error = jest.fn();
+    console.log = jest.fn();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("is a no-op that does not throw or call fetch when the API secret is unset in development", async () => {
+    process.env.NEXT_PUBLIC_ENVIRONMENT = "development";
+    delete process.env.GA4_MP_API_SECRET;
+
+    await expect(
+      sendConversionEvent({ name: "purchase", clientId: "111.222" }),
+    ).resolves.toBeUndefined();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+  });
+
+  it("reports missing API secret to Sentry as an error in staging", async () => {
+    delete process.env.GA4_MP_API_SECRET;
+
+    await sendConversionEvent({ name: "purchase", clientId: "111.222" });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("GA4 MP API secret missing"),
+      "error",
+    );
+  });
+
+  it("reports missing API secret to Sentry as an error in production", async () => {
+    process.env.NEXT_PUBLIC_ENVIRONMENT = "production";
+    process.env.NEXT_PUBLIC_PRODUCTION_GA_ID = "G-PRODID";
+    delete process.env.GA4_MP_API_SECRET;
+
+    await sendConversionEvent({ name: "purchase", clientId: "111.222" });
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("GA4 MP API secret missing"),
+      "error",
+    );
+  });
+
+  it("logs (not Sentry) and skips sending when client_id is missing", async () => {
+    await sendConversionEvent({ name: "purchase", clientId: undefined });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("client_id missing"),
+    );
+  });
+
+  it("targets the MP debug endpoint on staging", async () => {
+    await sendConversionEvent({ name: "purchase", clientId: "111.222" });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("https://www.google-analytics.com/debug/mp/collect"),
+      expect.any(Object),
+    );
+  });
+
+  it("targets the real MP endpoint on production", async () => {
+    process.env.NEXT_PUBLIC_ENVIRONMENT = "production";
+    process.env.NEXT_PUBLIC_PRODUCTION_GA_ID = "G-PRODID";
+
+    await sendConversionEvent({ name: "purchase", clientId: "111.222" });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://www.google-analytics.com/mp/collect?measurement_id=G-PRODID&api_secret=test-secret",
+      expect.any(Object),
+    );
+  });
+
+  it("surfaces non-empty validationMessages from the debug endpoint to Sentry", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({ validationMessages: [{ description: "bad param" }] }),
+      }),
+    ) as jest.Mock;
+
+    await sendConversionEvent({ name: "purchase", clientId: "111.222" });
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("bad param"),
+      "error",
+    );
+  });
+
+  it("reports a non-2xx response to Sentry without throwing", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: false, status: 500 }),
+    ) as jest.Mock;
+
+    await expect(
+      sendConversionEvent({ name: "purchase", clientId: "111.222" }),
+    ).resolves.toBeUndefined();
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("500"),
+      "error",
+    );
+  });
+
+  it("includes session_id in the payload when provided", async () => {
+    await sendConversionEvent({
+      name: "purchase",
+      clientId: "111.222",
+      sessionId: "333333333",
+    });
+
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.events[0].params.session_id).toBe("333333333");
+  });
+
+  it("swallows a network failure and reports it to Sentry instead of throwing", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.reject(new Error("network down")),
+    ) as jest.Mock;
+
+    await expect(
+      sendConversionEvent({ name: "purchase", clientId: "111.222" }),
+    ).resolves.toBeUndefined();
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("network down"),
+      "error",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Promotes staging into main
- Includes GA4 Measurement Protocol conversion tracking (purchase, generate_lead, sign_up), Sentry environment tagging fix, and related deploy wiring

## Commits
- fix(sentry): tag events with actual environment, not NODE_ENV (#554)
- feat(analytics): add GA4 Measurement Protocol sender
- chore(deploy): wire GA4_MP_API_SECRET through all environments
- feat(checkout): capture GA client_id and session_id into Stripe metadata
- feat(webhook): send GA4 purchase conversion on new paid subscription
- feat(leads): send GA4 generate_lead and sign_up conversions server-side

## Test plan
- CI build/deploy pipeline (production) — monitoring after merge